### PR TITLE
Add private field for user to use for custom formatters.

### DIFF
--- a/lib/formatter/options.ex
+++ b/lib/formatter/options.ex
@@ -40,6 +40,12 @@ defmodule Cldr.Calendar.Formatter.Options do
     defined by the `:formatter`.  It is most commonly
     used to apply an HTML id to an enclosing tag.
 
+  * `:private` is for your private use in your formatter.
+    For example if you wanted to pass a selected day and
+    format it differently, you could provide
+    `options.private = %{selected: ~D[2020-04-05]}` and
+    take advantage of it while formatting the days.
+
   * `:today` is any `Date.t` that represents today.
     It is commonly used to allow a formatting to
     appropriately format a date that is today
@@ -64,7 +70,8 @@ defmodule Cldr.Calendar.Formatter.Options do
     :class,
     :id,
     :today,
-    :day_names
+    :day_names,
+    :private
   ]
 
   @typedoc """
@@ -82,6 +89,7 @@ defmodule Cldr.Calendar.Formatter.Options do
     class: String.t | nil,
     id: String.t | nil,
     today: Date.t(),
+    private: any(),
     day_names: [{1..7, String.t}]
   }
 

--- a/test/cldr_calendars_format_test.exs
+++ b/test/cldr_calendars_format_test.exs
@@ -7,21 +7,24 @@ defmodule Cldr.Calendar.Format.Test do
       Cldr.Calendar.Format.month(2019, 4,
         formatter: Cldr.Calendar.Test.Formatter,
         caption: "My Caption",
-        calendar: Cldr.Calendar.Gregorian
+        calendar: Cldr.Calendar.Gregorian,
+        private: "My private options"
       )
 
     gregorian =
       Cldr.Calendar.Format.year(2019,
         formatter: Cldr.Calendar.Test.Formatter,
         caption: "My Caption",
-        calendar: Cldr.Calendar.Gregorian
+        calendar: Cldr.Calendar.Gregorian,
+        private: "My private options"
       )
 
     nrf =
       Cldr.Calendar.Format.year(2019,
         formatter: Cldr.Calendar.Test.Formatter,
         caption: "My Caption",
-        calendar: Cldr.Calendar.NRF
+        calendar: Cldr.Calendar.NRF,
+        private: "My private options"
       )
 
     {:ok, month: month, gregorian: gregorian, nrf: nrf}
@@ -33,6 +36,11 @@ defmodule Cldr.Calendar.Format.Test do
     assert formatted[:month] == 4
     assert length(formatted[:weeks]) == 6
     assert hd(formatted[:weeks])[:week_number] == 14
+  end
+
+  test "pass private options through", context do
+    formatted = context[:month]
+    assert formatted[:options].private == "My private options"
   end
 
   test "we have 12 months and a caption", context do
@@ -72,7 +80,7 @@ defmodule Cldr.Calendar.Format.Test do
   test "Weeks that don't start on Monday" do
     defmodule MyApp.Calendar.US do
       @moduledoc """
-      This is the same as a gregorian Calendar, but with Sunday starting the week.
+      This is the same as a gregorian calendar, but with Sunday starting the week.
       """
 
       use Cldr.Calendar.Base.Month, day_of_week: Cldr.Calendar.sunday(), cldr_backend: MyApp.Cldr

--- a/test/support/test_formatter.ex
+++ b/test/support/test_formatter.ex
@@ -7,13 +7,13 @@ defmodule Cldr.Calendar.Test.Formatter do
   end
 
   @impl true
-  def format_month(formatted_weeks, year, month, _options) do
-    %{year: year, month: month, weeks: formatted_weeks}
+  def format_month(formatted_weeks, year, month, options) do
+    %{year: year, month: month, weeks: formatted_weeks, options: options}
   end
 
   @impl true
-  def format_week(formatted_days, year, month, {_, week_number}, _options) do
-    %{year: year, month: month, days: formatted_days, week_number: week_number}
+  def format_week(formatted_days, year, month, {_, week_number}, options) do
+    %{year: year, month: month, days: formatted_days, week_number: week_number, options: options}
   end
 
   @impl true


### PR DESCRIPTION
While creating my own formatter that's use for a date picker, I found the need to pass along a selected date (separate from viewed date) for different formatting. I don't currently see a way to pass this information to my own formatter.

For example, in my case I'm using it in a Phoenix LiveComponent where viewed_date is altered by the user in the view, and selected_date is the one they have chosen.

```elixir
Cldr.Calendar.Format.month(
  @viewed_date.year,
  @viewed_date.month,
  formatter: __MODULE__, # this refers to the live component where it implements the formatter behaviour as well as the Phoenix LiveComponent behavior.
  id: "calendar",
  calendar: @viewed_date.calendar,
  private: %{
    selected: @selected_date,
    events: []
  }
)
```

![image](https://user-images.githubusercontent.com/643967/78532954-19461d00-77b6-11ea-9f64-fadad3b8855d.png)


I went with adding a `:private` field so it can serve as an escape hatch for users to put information through to their custom formatters. It reminds me of [Plug.Conn's private field](https://hexdocs.pm/plug/Plug.Conn.html#put_private/3), except this is specifically for the user. I'm open to alternative keys if you think that might be confusing.

I figure this also serves as a good playground for patterns to arise, and after which could be promoted to an option struct key, (like you're considering for `:events`)